### PR TITLE
Add SLF4J logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.github.lycoon</groupId>
   <artifactId>clash-api</artifactId>
-  <version>5.1.1</version>
+  <version>5.1.2</version>
 
   <!-- Project metadata -->
   <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.github.lycoon</groupId>
   <artifactId>clash-api</artifactId>
-  <version>5.1.2</version>
+  <version>5.1.3</version>
 
   <!-- Project metadata -->
   <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,13 @@
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.9</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/lycoon/clashapi/core/ClashAPI.kt
+++ b/src/main/java/com/lycoon/clashapi/core/ClashAPI.kt
@@ -20,6 +20,8 @@ import com.lycoon.clashapi.models.war.War
 import com.lycoon.clashapi.models.war.WarlogEntry
 import com.lycoon.clashapi.models.warleague.WarLeague
 import com.lycoon.clashapi.models.warleague.WarLeagueGroup
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * Create an instance of this class to start using the API.<br></br>
@@ -31,12 +33,15 @@ class ClashAPI : ClashAPIClient, IClashAPI
     constructor(tokens: List<String>) : super(tokens)
     constructor(email: String, password: String) : super(email, password)
 
+    private val log: Logger = LoggerFactory.getLogger(ClashAPI::class.java)
+
     // ##############################################
     // ||                Clans API                 ||
     // ##############################################
 
     override fun getWarLeagueGroup(clanTag: String): WarLeagueGroup
     {
+        log.trace("Getting war league group for clan {}", clanTag)
         val tag = formatTag(clanTag)
         val res = get("/clans/$tag/currentwar/leaguegroup")
         return deserialize(res.body.string())
@@ -44,6 +49,7 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getWarLeagueWar(warTag: String): War
     {
+        log.trace("Getting war league war {}", warTag)
         val tag = formatTag(warTag)
         val res = get("/clanwarleagues/wars/$tag")
         return deserialize(res.body.string())
@@ -51,6 +57,7 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getWarlog(clanTag: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<WarlogEntry>
     {
+        log.trace("Getting war log for clan {} with filter {}", clanTag, queryParamsBuilder)
         val tag = formatTag(clanTag)
         val res = get("/clans/$tag/warlog", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
@@ -58,12 +65,14 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getClans(queryParamsBuilder: ClanQueryParamsBuilder?): List<Clan>
     {
+        log.trace("Getting clans with filter {}", queryParamsBuilder)
         val res = get("/clans", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getCurrentWar(clanTag: String): War
     {
+        log.trace("Getting current war for clan {}", clanTag)
         val tag = formatTag(clanTag)
         val res = get("/clans/$tag/currentwar")
         return deserialize(res.body.string())
@@ -71,6 +80,7 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getClan(clanTag: String): Clan
     {
+        log.trace("Getting clan {}", clanTag)
         val tag = formatTag(clanTag)
         val res = get("/clans/$tag")
         return deserialize(res.body.string())
@@ -78,6 +88,7 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getClanMembers(clanTag: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<ClanMember>
     {
+        log.trace("Getting clan members for clan {} with filter {}", clanTag, queryParamsBuilder)
         val tag = formatTag(clanTag)
         val res = get("/clans/$tag/members", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
@@ -85,6 +96,7 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getCapitalRaidSeasons(clanTag: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<CapitalRaidSeason>
     {
+        log.trace("Getting capital raid seasons for clan {} with filter {}", clanTag, queryParamsBuilder)
         val tag = formatTag(clanTag)
         val res = get("/clans/$tag/capitalraidseasons", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
@@ -96,6 +108,7 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getPlayer(playerTag: String): Player
     {
+        log.trace("Getting player {}", playerTag)
         val tag = formatTag(playerTag)
         val res = get("/players/$tag")
         return deserialize(res.body.string())
@@ -103,6 +116,7 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun isVerifiedPlayer(playerTag: String, token: String): Boolean
     {
+        log.trace("Verifying player {} with token {}", playerTag, token)
         val tag = formatTag(playerTag)
         val res = post("/players/$tag/verifytoken", getRequestBody(TokenValidation(token)))
         return deserialize<TokenValidationResponse>(res.body.string()).status == "ok"
@@ -114,62 +128,73 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getCapitalLeagues(queryParamsBuilder: SimpleQueryParamsBuilder?): List<CapitalLeague>
     {
+        log.trace("Getting capital leagues with filter {}", queryParamsBuilder)
         val res = get("/capitalleagues", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getLeagues(queryParamsBuilder: SimpleQueryParamsBuilder?): List<League>
     {
+        log.trace("Getting leagues with filter {}", queryParamsBuilder)
         val res = get("/leagues", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getLeagueSeasonRankings(
-            leagueId: String, seasonId: String,
+            leagueId: String,
+            seasonId: String,
             queryParamsBuilder: SimpleQueryParamsBuilder?): List<PlayerRanking>
     {
+        log.trace("Getting league season rankings for league {} and season {} with filter {}", leagueId, seasonId, queryParamsBuilder)
         val res = get("/leagues/$leagueId/seasons/$seasonId", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getCapitalLeague(leagueId: String): CapitalLeague
     {
+        log.trace("Getting capital league {}", leagueId)
         val res = get("/capitalleagues/$leagueId")
         return deserialize(res.body.string())
     }
 
     override fun getBuilderBaseLeague(leagueId: String): BuilderBaseLeague
     {
+        log.trace("Getting builder base league {}", leagueId)
         val res = get("/builderbaseleagues/$leagueId")
         return deserialize(res.body.string())
     }
 
     override fun getBuilderBaseLeagues(queryParamsBuilder: SimpleQueryParamsBuilder?): List<BuilderBaseLeague>
     {
+        log.trace("Getting builder base leagues with filter {}", queryParamsBuilder)
         val res = get("/builderbaseleagues", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getLeague(leagueId: String): League
     {
+        log.trace("Getting league {}", leagueId)
         val res = get("/leagues/$leagueId")
         return deserialize(res.body.string())
     }
 
     override fun getLeagueSeasons(leagueId: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<LeagueSeason>
     {
+        log.trace("Getting league seasons for league {} with filter {}", leagueId, queryParamsBuilder)
         val res = get("/leagues/$leagueId/seasons", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getWarLeague(leagueId: String): WarLeague
     {
+        log.trace("Getting war league {}", leagueId)
         val res = get("/warleagues/$leagueId")
         return deserialize(res.body.string())
     }
 
     override fun getWarLeagues(queryParamsBuilder: SimpleQueryParamsBuilder?): List<WarLeague>
     {
+        log.trace("Getting war leagues with filter {}", queryParamsBuilder)
         val res = get("/warleagues", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
@@ -180,18 +205,21 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getClanRankings(locationId: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<ClanRanking>
     {
+        log.trace("Getting clan rankings for location {} with filter {}", locationId, queryParamsBuilder)
         val res = get("/locations/${locationId}/rankings/clans", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getPlayerRankings(locationId: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<PlayerRanking>
     {
+        log.trace("Getting player rankings for location {} with filter {}", locationId, queryParamsBuilder)
         val res = get("/locations/${locationId}/rankings/players", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getClanBuilderBaseRankings(locationId: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<ClanBuilderBaseRanking>
     {
+        log.trace("Getting clan builder base rankings for location {} with filter {}", locationId, queryParamsBuilder)
         val res = get("/locations/${locationId}/rankings/clans-builder-base", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
@@ -199,12 +227,14 @@ class ClashAPI : ClashAPIClient, IClashAPI
     @Deprecated("Use getClanBuilderBaseRankings instead")
     override fun getClanVersusRankings(locationId: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<ClanBuilderBaseRanking>
     {
+        log.trace("Getting clan versus rankings for location {} with filter {}", locationId, queryParamsBuilder)
         val res = get("/locations/${locationId}/rankings/clans-versus", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getPlayerBuilderBaseRankings(locationId: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<PlayerBuilderBaseRanking>
     {
+        log.trace("Getting player builder base rankings for location {} with filter {}", locationId, queryParamsBuilder)
         val res = get("/locations/${locationId}/rankings/players-builder-base", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
@@ -212,24 +242,28 @@ class ClashAPI : ClashAPIClient, IClashAPI
     @Deprecated("Use getPlayerBuilderBaseRankings instead")
     override fun getPlayerVersusRankings(locationId: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<PlayerBuilderBaseRanking>
     {
+        log.trace("Getting player versus rankings for location {} with filter {}", locationId, queryParamsBuilder)
         val res = get("/locations/${locationId}/rankings/players-versus", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getLocations(queryParamsBuilder: SimpleQueryParamsBuilder?): List<Location>
     {
+        log.trace("Getting locations with filter {}", queryParamsBuilder)
         val res = get("/locations", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getCapitalRankings(locationId: String, queryParamsBuilder: SimpleQueryParamsBuilder?): List<CapitalRanking>
     {
+        log.trace("Getting capital rankings for location {} with filter {}", locationId, queryParamsBuilder)
         val res = get("/locations/$locationId/rankings/capitals", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getLocation(locationId: String): Location
     {
+        log.trace("Getting location {}", locationId)
         val res = get("/locations/$locationId")
         return deserialize(res.body.string())
     }
@@ -240,6 +274,7 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getGoldPass(): GoldPassSeason
     {
+        log.trace("Getting gold pass")
         val res = get("/goldpass/seasons/current")
         return deserialize(res.body.string())
     }
@@ -250,12 +285,14 @@ class ClashAPI : ClashAPIClient, IClashAPI
 
     override fun getPlayerLabels(queryParamsBuilder: SimpleQueryParamsBuilder?): List<Label>
     {
+        log.trace("Getting player labels with filter {}", queryParamsBuilder)
         val res = get("/labels/players", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }
 
     override fun getClanLabels(queryParamsBuilder: SimpleQueryParamsBuilder?): List<Label>
     {
+        log.trace("Getting clan labels with filter {}", queryParamsBuilder)
         val res = get("/labels/clans", queryParamsBuilder)
         return unwrapList(deserialize(res.body.string()))
     }

--- a/src/main/java/com/lycoon/clashapi/core/ClashAPIClient.kt
+++ b/src/main/java/com/lycoon/clashapi/core/ClashAPIClient.kt
@@ -8,6 +8,7 @@ import com.lycoon.clashapi.core.auth.KeyManager
 import com.lycoon.clashapi.core.auth.TokenList
 import com.lycoon.clashapi.core.exceptions.ClashAPIException
 import okhttp3.*
+import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -29,6 +30,7 @@ abstract class ClashAPIClient
     }
 
     private val client: OkHttpClient = OkHttpClient.Builder().cookieJar(APICookieJar()).build()
+    private val log: org.slf4j.Logger = LoggerFactory.getLogger(ClashAPIClient::class.java)
     private val tokens: TokenList
 
     private fun getBaseAPIRequest(suffix: String, queryParamsBuilder: QueryParamsBuilder? = null): Request.Builder
@@ -46,6 +48,9 @@ abstract class ClashAPIClient
     {
         val req = getBaseAPIRequest(url, queryParamsBuilder).build()
         val res = client.newCall(req).execute()
+
+        log.debug("Got response: {}", res)
+
         return CoreUtils.checkResponse(res)
     }
 
@@ -54,6 +59,9 @@ abstract class ClashAPIClient
     {
         val req = getBaseAPIRequest(url).post(body).build()
         val res = client.newCall(req).execute()
+
+        log.debug("Got response: {}", res)
+
         return CoreUtils.checkResponse(res)
     }
 }


### PR DESCRIPTION
I'm getting a weird bug in an application where I'm using this API where Kotlin serialization is failing with the error: `Caused by: kotlinx.serialization.MissingFieldException: Field 'role' is required for type with serial name 'com.lycoon.clashapi.models.clan.ClanMember', but it was missing at path: $.memberList[0] at path: $.memberList[0] at path: $.memberList[0]`.

Doing a Postman request to the same API, role is present for `$.memberList[0]` so I'm not sure what response Kotlin serialization is getting. I decided to add trace and debug logging so that I can get better visibility into what's going on in my application.

I only added the SLF4J-api and not a logging implementation so that consumers of the library can configure their own logging implementation if they want.