### PR TITLE
Fix unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,10 +66,12 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.1</version>
+      <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.github.lycoon</groupId>
   <artifactId>clash-api</artifactId>
-  <version>5.1.1</version>
+  <version>5.1.3</version>
 
   <!-- Project metadata -->
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/lycoon/clashapi/models/war/WarlogClan.kt
+++ b/src/main/java/com/lycoon/clashapi/models/war/WarlogClan.kt
@@ -13,5 +13,5 @@ data class WarlogClan(
     val attacks: Int = 0, // if warleague result or opponent in warlog clan
     val stars: Int = 0,
     val expEarned: Int = 0, // if warleague result or opponent in warlog clan
-    val members: List<WarMember>
+    val members: List<WarMember> = emptyList()
 )

--- a/src/main/java/com/lycoon/clashapi/models/war/WarlogEntry.kt
+++ b/src/main/java/com/lycoon/clashapi/models/war/WarlogEntry.kt
@@ -11,5 +11,5 @@ data class WarlogEntry
     val attacksPerMember: Int = 0,
     val opponent: WarlogClan? = null,
     val endTime: String? = null,
-    val result: WarResult
+    val result: WarResult? = null,
 )

--- a/src/test/java/com/lycoon/clashapi/core/ClashAPITest.kt
+++ b/src/test/java/com/lycoon/clashapi/core/ClashAPITest.kt
@@ -1,16 +1,19 @@
-import com.lycoon.clashapi.core.ClanQueryParamsBuilder
-import junit.framework.TestCase
-import com.lycoon.clashapi.core.ClashAPI
+package com.lycoon.clashapi.core
+
+import com.lycoon.clashapi.core.exceptions.NotFoundException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.io.FileInputStream
 import java.io.IOException
-import com.lycoon.clashapi.core.exceptions.NotFoundException
 import java.util.*
 
 const val CLAN_TAG = "UPCU2098"
 const val CONFIG = "tokens.properties"
 const val PLAYER_TAG = "PGYR0PR"
 
-class ClashAPITest(playerTestMethod: String?) : TestCase(playerTestMethod) {
+internal class ClashAPITest() {
     private val clashAPI: ClashAPI
 
     init {
@@ -24,128 +27,141 @@ class ClashAPITest(playerTestMethod: String?) : TestCase(playerTestMethod) {
         clashAPI = ClashAPI(tokens.getProperty("email"), tokens.getProperty("password"))
     }
 
-    /*fun testWarlog() {
+    @Test
+    internal fun testWarlog() {
         val warlog = clashAPI.getWarlog(CLAN_TAG)
         assertNotNull(warlog)
-    }*/
+    }
 
-    fun testClanMembers() {
+    @Test
+    internal fun testClanMembers() {
         val clanMembers = clashAPI.getClanMembers(CLAN_TAG)
         assertNotNull(clanMembers)
     }
 
-    fun testLeague() {
+    @Test
+    internal fun testLeague() {
         val league = clashAPI.getLeague("29000000")
         assertNotNull(league)
     }
 
-    fun testLeagues() {
+    @Test
+    internal fun testLeagues() {
         val leagues = clashAPI.getLeagues()
         assertNotNull(leagues)
     }
 
-    fun testLocation() {
+    @Test
+    internal fun testLocation() {
         val location = clashAPI.getLocation("32000000")
         assertNotNull(location)
     }
 
-    fun testLocations() {
+    @Test
+    internal fun testLocations() {
         val locations = clashAPI.getLocations()
         assertNotNull(locations)
     }
 
-    /*fun testWarLeague() {
+    @Test
+    internal fun testWarLeague() {
         val warLeague = clashAPI.getWarLeague("48000000")
         assertNotNull(warLeague)
     }
 
-    fun testWarLeagues() {
+    @Test
+    internal fun testWarLeagues() {
         val warLeagues = clashAPI.getWarLeagues()
         assertNotNull(warLeagues)
-    }*/
+    }
 
-    fun testPlayerLabels() {
+    @Test
+    internal fun testPlayerLabels() {
         val playerLabels = clashAPI.getPlayerLabels()
         assertNotNull(playerLabels)
     }
 
-    fun testClanLabels() {
+    @Test
+    internal fun testClanLabels() {
         val clanLabels = clashAPI.getClanLabels()
         assertNotNull(clanLabels)
     }
 
-    /*fun testWarLeagueGroup() {
-        val warLeagueGroup = clashAPI.getWarLeagueGroup("#C0GJPLJG")
-        assertNotNull(warLeagueGroup)
-        print(warLeagueGroup.toString())
+    @Test
+    internal fun testWarLeagueGroup() {
+        try {
+            val warLeagueGroup = clashAPI.getWarLeagueGroup(CLAN_TAG)
+            assertNotNull(warLeagueGroup)
+        } catch (ex: NotFoundException) {
+            // Do nothing
+            // This test will fail if the clan is not in a war league
+        }
     }
 
-    fun testWarLeagueWar() {
+    @Test
+    internal fun testWarLeagueWar() {
         val warLeagueWar = clashAPI.getWarLeagueWar("#0")
         assertNotNull(warLeagueWar)
-        print(warLeagueWar.toString())
     }
 
-    fun testClanWar() {
+    @Test
+    internal fun testClanWar() {
         val clanWar = clashAPI.getCurrentWar("#C0GJPLJG")
         assertNotNull(clanWar)
-        print(clanWar.toString())
-    }*/
+    }
 
-    fun testPlayerWithoutSharp() {
+    @Test
+    internal fun testPlayerWithoutSharp() {
         val player = clashAPI.getPlayer(PLAYER_TAG)
         assertNotNull(player)
-        assertEquals(player.name, "Bowwn")
-        assertEquals(player.tag, "#$PLAYER_TAG")
+        assertEquals("Bowwn", player.name)
+        assertEquals("#$PLAYER_TAG", player.tag)
     }
 
-    fun testClanWithoutSharp() {
+    @Test
+    internal fun testClanWithoutSharp() {
         val clan = clashAPI.getClan(CLAN_TAG)
         assertNotNull(clan)
-        assertEquals(clan.name, "Amnésia")
-        assertEquals(clan.tag, "#$CLAN_TAG")
+        assertEquals("Amnésia", clan.name)
+        assertEquals("#$CLAN_TAG", clan.tag)
     }
 
-    fun testPlayerWithSharp() {
+    @Test
+    internal fun testPlayerWithSharp() {
         val player = clashAPI.getPlayer("#$PLAYER_TAG")
         assertNotNull(player)
-        assertEquals(player.name, "Bowwn")
-        assertEquals(player.tag, "#$PLAYER_TAG")
+        assertEquals("Bowwn", player.name)
+        assertEquals("#$PLAYER_TAG", player.tag)
     }
 
-    fun testNewPlayer() {
+    @Test
+    internal fun testNewPlayer() {
         val player = clashAPI.getPlayer("#GL2GLGLYR")
         assertNotNull(player)
     }
 
-    fun testClanWithSharp() {
+    @Test
+    internal fun testClanWithSharp() {
         val clan = clashAPI.getClan("#$CLAN_TAG")
         assertNotNull(clan)
-        assertEquals(clan.name, "Amnésia")
-        assertEquals(clan.tag, "#$CLAN_TAG")
+        assertEquals("Amnésia", clan.name)
+        assertEquals("#$CLAN_TAG", clan.tag)
     }
 
-    fun testClanSearch() {
+    @Test
+    internal fun testClanSearch() {
         val query = ClanQueryParamsBuilder(name = "toto");
         val clans = clashAPI.getClans(query);
         assertNotNull(clans)
     }
 
-    fun testPlayer404() {
-        try {
-            clashAPI.getPlayer("404")
-        } catch (e: NotFoundException) {
-            return
-        }
-        fail()
+    @Test
+    internal fun testPlayer404() {
+        assertThrows<NotFoundException> { clashAPI.getPlayer("404") }
     }
 
-    fun testClan404() {
-        try {
-            clashAPI.getClan("404")
-        } catch (e: NotFoundException) {
-            return
-        }
-        fail()
+    @Test
+    internal fun testClan404() {
+        assertThrows<NotFoundException> { clashAPI.getClan("404") }
     }
 }


### PR DESCRIPTION
- Upgraded the JUnit version to JUnit Juptiter 5.10.1 (the most recent version).
- Uncommented the disabled unit tests
- Fixed the order of `assertEquals` calls so that the expected value is first and the actual value is second
- Fixed a bug where old WarlogClan items can have a null member list
- Fixed a bug where sometimes the war result is null (this happens with the test clan in their 4th most recent war).
- Updated the 404 tests to use `assertThrows` instead of manually failing the test