### PR TITLE
Fix coLeader serialization name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.github.lycoon</groupId>
   <artifactId>clash-api</artifactId>
-  <version>5.1.1</version>
+  <version>5.1.2</version>
 
   <!-- Project metadata -->
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/lycoon/clashapi/models/player/enums/Role.kt
+++ b/src/main/java/com/lycoon/clashapi/models/player/enums/Role.kt
@@ -10,5 +10,5 @@ enum class Role
     @SerialName("member") MEMBER,
     @SerialName("leader") LEADER,
     @SerialName("admin") ADMIN,
-    @SerialName("coleader") COLEADER
+    @SerialName("coLeader") COLEADER
 }


### PR DESCRIPTION
Fixed the bug I referenced in [PR 38](https://github.com/Lycoon/clash-api/pull/38). The issue is that `coLeader` was mis-named `coleader` in `Role.kt`